### PR TITLE
Remove leading dot from nullglob

### DIFF
--- a/zshrc.d.plugin.zsh
+++ b/zshrc.d.plugin.zsh
@@ -16,7 +16,7 @@ function source_zshrcdir() {
 
   # source configdir
   local f
-  local files=("$configdir"/*.{sh,zsh}(.N))
+  local files=("$configdir"/*.{sh,zsh}(N))
   for f in ${(o)files}; do
     # ignore files that begin with a tilde
     case $f:t in ~*) continue;; esac


### PR DESCRIPTION
I guess that the main reason for using the nullglob symbol was to suppress errors. However, using that with a leading dot `.` ignores symlinks as well. 
Since all my dotfiles are symlinked, changing this was necessary.

The drawback is that directories are now also included.
I wonder if there's a way to exclude only them...
